### PR TITLE
fix syntax error on python 3.7

### DIFF
--- a/wazo_plugind_cli/command.py
+++ b/wazo_plugind_cli/command.py
@@ -1,4 +1,4 @@
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import queue
@@ -30,8 +30,8 @@ class _BaseAsyncCommand(_BasePlugindCommand):
                                        config['bus']['exchange_type'])
 
     def execute(self, *args):
-        async = args[-1]
-        if async:
+        async_ = args[-1]
+        if async_:
             self.execute_async(*args[:-1])
         else:
             self.execute_sync(*args[:-1])


### PR DESCRIPTION
"async" is now part of the python syntax

Here's the error that I got

```
Setting up wazo-plugind-cli (19.13~20190904.061358.dd6aba2.deb10) ...
  File "/usr/lib/python3/dist-packages/wazo_plugind_cli/command.py", line 33
    async = args[-1]
          ^
SyntaxError: invalid syntax

dpkg: error processing package wazo-plugind-cli (--configure):
 installed wazo-plugind-cli package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 wazo-plugind-cli
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
