### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/wazo_plugind_cli/config.py
+++ b/wazo_plugind_cli/config.py
@@ -12,8 +12,7 @@ from xivo.config_helper import parse_config_file
 _DEFAULT_CONFIG = {
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-plugind-cli-key.yml',
     },


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the CLI reaches wazo-auth at runtime; wrong deployment order or mismatched nginx/auth config would break authentication for plugind-cli.
> 
> **Overview**
> **wazo-plugind-cli** now targets **wazo-auth** through the nginx internal entry point instead of the auth daemon port.
> 
> In `_DEFAULT_CONFIG`, `auth.port` changes from **9497** to **80**, and the explicit `auth.prefix` entry is removed so **`wazo-auth-client`** can use its default **`/api/auth`**. This must land together with the nginx internal route and wazo-auth location from the dependent PRs, or internal auth requests will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 474942a81fabf5deddfa6c618295f61375ebe4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->